### PR TITLE
chore(dependencies): update cassandra-driver to v4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,9 +1349,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "cassandra-driver": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-3.6.0.tgz",
-      "integrity": "sha512-CkN3V+oPaF5RvakUjD3uUjEm8f6U8S0aT1+YqeQsVT3UDpPT2K8SOdNDEHA1KjamakHch6zkDgHph1xWyqBGGw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-4.1.0.tgz",
+      "integrity": "sha512-MHI8PcCCaPEa9DKsP+L6MsokrK5Twhu4UBb3reyEAezB0XFhu7DnjDcfWuDHpzmuCY3OSmgskO1pnoz1GsRIIA==",
       "requires": {
         "long": "^2.2.0"
       }
@@ -1366,6 +1366,16 @@
         "durations": "^3.4.1",
         "lodash": "^4.13.1",
         "q": "^1.4"
+      },
+      "dependencies": {
+        "cassandra-driver": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-3.6.0.tgz",
+          "integrity": "sha512-CkN3V+oPaF5RvakUjD3uUjEm8f6U8S0aT1+YqeQsVT3UDpPT2K8SOdNDEHA1KjamakHch6zkDgHph1xWyqBGGw==",
+          "requires": {
+            "long": "^2.2.0"
+          }
+        }
       }
     },
     "chai": {
@@ -3371,10 +3381,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bluebird": "^3.5.5",
     "body-parser": "^1.19.0",
     "bunyan": "^1.8.12",
-    "cassandra-driver": "^3.5.0",
+    "cassandra-driver": "^4.1.0",
     "cassandra-migration": "^2.7.0",
     "copy-dir": "^0.3.0",
     "cron": "^1.7.1",

--- a/src/config/databaseConfig.js
+++ b/src/config/databaseConfig.js
@@ -8,7 +8,7 @@ const config = {
     cassandraReplicationFactor: process.env.CASSANDRA_REPLICATION_FACTOR || 1,
     cassandraConsistency: getCassandraConsistencyByName(process.env.CASSANDRA_CONSISTENCY),
     cassandraKeyspaceStrategy: process.env.CASSANDRA_KEY_SPACE_STRATEGY || 'SimpleStrategy',
-    cassandraLocalDataCenter: process.env.CASSANDRA_LOCAL_DATA_CENTER,
+    cassandraLocalDataCenter: process.env.CASSANDRA_LOCAL_DATA_CENTER || 'datacenter1',
     sqliteStorage: process.env.SQLITE_STORAGE || 'predator'
 };
 

--- a/src/database/cassandra-handler/cassandra.js
+++ b/src/database/cassandra-handler/cassandra.js
@@ -58,7 +58,8 @@ async function createClient() {
     const config = {
         contactPoints: String(databaseConfig.address).split(','),
         keyspace: databaseConfig.name,
-        authProvider
+        authProvider,
+        localDataCenter: databaseConfig.cassandraLocalDataCenter
     };
 
     let cassandraClient = new cassandra.Client(config);

--- a/src/database/cassandra-handler/cassandraMigration.js
+++ b/src/database/cassandra-handler/cassandraMigration.js
@@ -213,7 +213,8 @@ function buildClient(keyspace) {
     let authProvider = new cassandra.auth.PlainTextAuthProvider(args.cassandra_username, args.cassandra_password);
     let cassandraClient = {
         contactPoints: args.cassandra_url.split(','),
-        authProvider: authProvider
+        authProvider: authProvider,
+        localDataCenter: args.cassandra_local_data_center
     };
 
     if (keyspace) {


### PR DESCRIPTION
[According to cassandra-driver upgrade notes](https://docs.datastax.com/en/developer/nodejs-driver/4.1/upgrade-guide/)

> `localDataCenter` is now a required Client option
When using DCAwareRoundRobinPolicy, which is used by default, a local data center must now be provided to the Client options parameter as `localDataCenter`. This is necessary to prevent routing requests to nodes in remote data centers.

Default value chosen for `localDataCenter` is `datacenter1`