### PR TITLE
chore(ui): replace run and save buttons with icons (#449)

### DIFF
--- a/ui/src/components/IconButton/index.js
+++ b/ui/src/components/IconButton/index.js
@@ -1,0 +1,27 @@
+import React, { Fragment } from 'react';
+import Spinner from '../Spinner';
+import css from './style.scss';
+
+const IconButton = (props) => {
+  const { className = '', inverted, disabled, width, spinner, height, color, onClick, style, ...rest } = props
+
+  return (
+    <Fragment>
+      {spinner
+        ? <span className={css['spinner-span']} style={{ ...style, width, height }}>
+          <Spinner className={css['icon']} invertedPrimaryColor='#406eff' invertedSecondaryColor='#d9e2ff' inverted={inverted} size={'32px'} thickness={'3px'} />
+        </span>
+        : <div
+          className={`${css['icon-button']} ${className}`}
+          style={{ ...style, width, height }}
+          data-disabled={disabled}
+          onClick={(disabled || spinner) ? undefined : onClick}
+          {...rest}
+        >
+          {rest.children}
+        </div>}
+    </Fragment>
+  )
+}
+
+export default IconButton;

--- a/ui/src/components/IconButton/index.js
+++ b/ui/src/components/IconButton/index.js
@@ -1,15 +1,22 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import Spinner from '../Spinner';
 import css from './style.scss';
+import TooltipWrapper from '../TooltipWrapper';
 
 const IconButton = (props) => {
-  const { className = '', inverted, disabled, width, spinner, height, color, onClick, style, ...rest } = props
+  const { className = '', inverted, disabled, width, spinner, height, onClick, style, children, title, ...rest } = props
 
   return (
-    <Fragment>
+    <TooltipWrapper
+      content={<div>{title}</div>}
+      place='top'
+      dataId={`tooltipKey_${title}`}
+      offset={{ top: 1 }}
+      shouldShow={!disabled && !spinner}
+    >
       {spinner
         ? <span className={css['spinner-span']} style={{ ...style, width, height }}>
-          <Spinner className={css['icon']} invertedPrimaryColor='#406eff' invertedSecondaryColor='#d9e2ff' inverted={inverted} size={'32px'} thickness={'3px'} />
+          <Spinner className={css['icon']} inverted={inverted} />
         </span>
         : <div
           className={`${css['icon-button']} ${className}`}
@@ -18,9 +25,9 @@ const IconButton = (props) => {
           onClick={(disabled || spinner) ? undefined : onClick}
           {...rest}
         >
-          {rest.children}
+          {children}
         </div>}
-    </Fragment>
+    </TooltipWrapper>
   )
 }
 

--- a/ui/src/components/IconButton/style.scss
+++ b/ui/src/components/IconButton/style.scss
@@ -1,0 +1,35 @@
+@import "../styles/colors";
+
+.icon-button {
+  cursor: pointer;
+  color: darken($glowing-blue, 10%);
+  transition: color 0.25s ease-in-out;
+
+  &[data-disabled=true] {
+    pointer-events: none;
+    box-shadow: none;
+    color: $disabled-grey-button;
+    background-color: $white;
+  }
+
+  &:not([data-disabled=true]):hover {
+    color: darken($glowing-blue, 20%);
+  }
+
+  & > svg {
+    filter: unset;
+    transition: filter 0.2s;
+  }
+
+  &:not([data-disabled=true]) > svg:hover {
+    -webkit-filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));      
+    filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));  
+  }
+}
+
+.spinner-span {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}

--- a/ui/src/components/IconButton/style.scss
+++ b/ui/src/components/IconButton/style.scss
@@ -2,7 +2,7 @@
 
 .icon-button {
   cursor: pointer;
-  color: darken($glowing-blue, 10%);
+  color: $glowing-blue;
   transition: color 0.25s ease-in-out;
 
   &[data-disabled=true] {
@@ -13,7 +13,7 @@
   }
 
   &:not([data-disabled=true]):hover {
-    color: darken($glowing-blue, 20%);
+    color: darken($glowing-blue, 10%);
   }
 
   & > svg {
@@ -22,8 +22,8 @@
   }
 
   &:not([data-disabled=true]) > svg:hover {
-    -webkit-filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));      
-    filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));  
+    -webkit-filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, 0.25));      
+    filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, 0.25));  
   }
 }
 

--- a/ui/src/features/components/JobForm/index.js
+++ b/ui/src/features/components/JobForm/index.js
@@ -9,7 +9,6 @@ import RactangleAlignChildrenLeft from '../../../components/RectangleAlign/Recta
 import { validate } from './validator';
 import CronViewer from './cronViewer';
 import Modal from '../Modal';
-import Button from '../../../components/Button'
 import TitleInput from '../../../components/TitleInput'
 import Input from '../../../components/Input'
 import FormWrapper from '../../../components/FormWrapper';
@@ -24,6 +23,10 @@ import { inputTypes, testTypes } from './constants';
 import MultiSelect from '../../../components/MultiSelect/MultiSelect.export';
 import NumericInput from '../../../components/NumericInput';
 import InfoToolTip from '../InfoToolTip';
+import { faSave } from '@fortawesome/free-regular-svg-icons';
+import { faPlayCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import IconButton from '../../../components/IconButton';
 
 const DESCRIPTION = 'Predator executes tests through jobs. Use this form to specify the parameters for the job you want to execute.';
 
@@ -368,12 +371,27 @@ class Form extends React.Component {
                   </RactangleAlignChildrenLeft>}
                 </Fragment>);
               }, this)}
-              <div className={style.buttons}>
-                <Button style={{ marginRight: '5px' }} inverted onClick={closeDialog}>Cancel</Button>
-                <Button style={{ marginRight: '5px' }} spinner={processingAction} hover disabled={!this.state.cron_expression || !!this.isThereErrorOnForm()}
-                  onClick={() => { this.whenSubmit(false) }}>Schedule</Button>
-                <Button spinner={processingAction} hover disabled={!!this.isThereErrorOnForm()}
-                  onClick={() => this.whenSubmit(true)}>{this.state.cron_expression ? 'Schedule & Run' : 'Run'}</Button>
+              <div className={style.icons}>
+                <IconButton style={{ marginRight: '12px' }}
+                  spinner={processingAction}
+                  disabled={!this.state.cron_expression || !!this.isThereErrorOnForm()}
+                  onClick={() => { this.whenSubmit(false) }}
+                  height='56px'
+                  width='56px'
+                  inverted
+                  title='Schedule'>
+                  <FontAwesomeIcon icon={faSave} size='4x' />
+                </IconButton>
+                <IconButton style={{ marginRight: '16px' }}
+                  spinner={processingAction}
+                  disabled={!!this.isThereErrorOnForm()}
+                  onClick={() => this.whenSubmit(true)}
+                  height='56px'
+                  width='56px'
+                  inverted
+                  title={this.state.cron_expression ? 'Schedule & Run' : 'Run'}>
+                  <FontAwesomeIcon icon={faPlayCircle} size='4x' />
+                </IconButton>
               </div>
               {serverError &&
               <ErrorDialog closeDialog={() => {

--- a/ui/src/features/components/JobForm/index.js
+++ b/ui/src/features/components/JobForm/index.js
@@ -23,8 +23,7 @@ import { inputTypes, testTypes } from './constants';
 import MultiSelect from '../../../components/MultiSelect/MultiSelect.export';
 import NumericInput from '../../../components/NumericInput';
 import InfoToolTip from '../InfoToolTip';
-import { faSave } from '@fortawesome/free-regular-svg-icons';
-import { faPlayCircle } from '@fortawesome/free-solid-svg-icons';
+import { faClock, faPlayCircle } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import IconButton from '../../../components/IconButton';
 
@@ -372,25 +371,25 @@ class Form extends React.Component {
                 </Fragment>);
               }, this)}
               <div className={style.icons}>
-                <IconButton style={{ marginRight: '12px' }}
+                <IconButton style={{ marginRight: '8px' }}
                   spinner={processingAction}
                   disabled={!this.state.cron_expression || !!this.isThereErrorOnForm()}
                   onClick={() => { this.whenSubmit(false) }}
-                  height='56px'
-                  width='56px'
                   inverted
+                  width='28px'
+                  height='28px'
                   title='Schedule'>
-                  <FontAwesomeIcon icon={faSave} size='4x' />
+                  <FontAwesomeIcon icon={faClock} size='2x' />
                 </IconButton>
-                <IconButton style={{ marginRight: '16px' }}
+                <IconButton
                   spinner={processingAction}
                   disabled={!!this.isThereErrorOnForm()}
                   onClick={() => this.whenSubmit(true)}
-                  height='56px'
-                  width='56px'
                   inverted
+                  width='28px'
+                  height='28px'
                   title={this.state.cron_expression ? 'Schedule & Run' : 'Run'}>
-                  <FontAwesomeIcon icon={faPlayCircle} size='4x' />
+                  <FontAwesomeIcon icon={faPlayCircle} size='2x' />
                 </IconButton>
               </div>
               {serverError &&

--- a/ui/src/features/components/JobForm/style.scss
+++ b/ui/src/features/components/JobForm/style.scss
@@ -1,5 +1,5 @@
 
-.buttons {
+.icons {
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
This PR will resolve issue #449. 

What I did as part of this PR was:
1. removed Cancel button as per issue
2. created a new component called IconButton - it's not actually a button, but behaves like one i.e. it's clickable, it can be disabled etc.
3. since now the buttons don't contain any text, I gave the div within the new component the title attribute and basically moved the text that was previously showing inside the old buttons in the title. So, now when a user hovers over the icons they will get a bit more context around what the icon buttons are for (when you hover over, a little message appears that says Schedule/Schedule & Run/Run
4. also added some CSS - the colour of the icons before and after hover are darker than the previous buttons but decided to keep them in the blue range

Let me know what you think.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/35401262/95249836-31543300-0811-11eb-88b6-692d5102a957.png">

