### PR TITLE
fix(431): default expanded to false for CollapsibleStep

### DIFF
--- a/ui/src/features/components/TestForm/collapsibleStep.js
+++ b/ui/src/features/components/TestForm/collapsibleStep.js
@@ -10,7 +10,7 @@ export default class CollapsibleStep extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            expanded: true
+            expanded: false
         }
     }
 


### PR DESCRIPTION
This PR resolves issue [#431](https://github.com/Zooz/predator/issues/431).

Steps to resolve:
1. In ui/src/features/components/TestForm/collapsibleStep.js, set the default state value of expanded to **_false_** instead of **_true_**.

Result: Each step displays in a collapsed state when initializing Tests page in Edit or Create mode. Screenshot below:

<img width="1413" alt="Screen Shot 2020-10-06 at 7 44 48 PM" src="https://user-images.githubusercontent.com/5702024/95275462-2b108780-080e-11eb-80ea-e75a19fb6957.png">
