### PR TITLE
fix(jobs, reports): fail report as failed immediately on job creation failure

### DIFF
--- a/src/jobs/models/jobManager.js
+++ b/src/jobs/models/jobManager.js
@@ -356,6 +356,7 @@ async function runJob(job, configData) {
     } catch (error) {
         logger.error({ id: job.id, error: error }, 'Unable to run scheduled job.');
         await failReport(report);
+        throw error;
     }
     return report;
 }

--- a/src/jobs/models/jobManager.js
+++ b/src/jobs/models/jobManager.js
@@ -33,7 +33,7 @@ module.exports.reloadCronJobs = async () => {
         const jobs = await databaseConnector.getJobs(contextId);
         jobs.forEach(async function (job) {
             if (job.cron_expression !== null) {
-                addCron(job.id.toString(), job, job.cron_expression, configData);
+                addCron(job, job.cron_expression, configData);
             }
         });
     } catch (error) {
@@ -63,23 +63,16 @@ module.exports.createJob = async (job) => {
         const insertedJob = await databaseConnector.insertJob(jobId, job, contextId);
         logger.info('Job saved successfully to database');
         if (job.run_immediately) {
-            const latestDockerImage = await dockerHubConnector.getMostRecentRunnerTag();
-            const test = await testsManager.getTest(job.test_id);
-            report = await createReportForJob(test, insertedJob);
-            const jobSpecificPlatformRequest = await createJobRequest(jobId, report.report_id, insertedJob, latestDockerImage, configData, contextId);
-            await jobConnector.runJob(jobSpecificPlatformRequest, job);
+            report = await runJob(insertedJob, configData);
         }
         if (job.cron_expression) {
-            addCron(jobId, insertedJob, job.cron_expression, configData);
+            report = { report_id: undefined };
+            addCron(insertedJob, job.cron_expression, configData);
         }
-        logger.info('Job deployed successfully');
+        logger.info(`Job ${jobId} deployed successfully`);
         return createResponse(jobId, job, report.report_id);
     } catch (error) {
         logger.error(error, 'Error occurred trying to create new job');
-        if (report) {
-            logger.info('Removing the failed job report');
-            await reportsManager.failReport(report);
-        }
         throw error;
     }
 };
@@ -163,7 +156,7 @@ module.exports.updateJob = async (jobId, jobConfig) => {
         cronJobs[jobId].stop();
         delete cronJobs[jobId];
     }
-    addCron(jobId, job[0], job[0].cron_expression, configData);
+    addCron(job[0], job[0].cron_expression, configData);
     logger.info('Job updated successfully to database');
 };
 
@@ -277,30 +270,17 @@ async function createJobRequest(jobId, reportId, jobBody, dockerImage, configDat
     return jobRequest;
 }
 
-function addCron(jobId, job, cronExpression, configData) {
+function addCron(job, cronExpression, configData) {
     const scheduledJob = new CronJob(cronExpression, async function () {
-        let report = null;
-        try {
-            if (job.enabled === false) {
-                logger.info(`Skipping job with id: ${jobId} as it's currently disabled`);
-            } else {
-                const latestDockerImage = await dockerHubConnector.getMostRecentRunnerTag();
-                const test = await testsManager.getTest(job.test_id);
-                report = await createReportForJob(test, job);
-                const jobSpecificPlatformConfig = await createJobRequest(jobId, report.report_id, job, latestDockerImage, configData);
-                await jobConnector.runJob(jobSpecificPlatformConfig, job);
-            }
-        } catch (error) {
-            logger.error({ id: jobId, error: error }, 'Unable to run scheduled job.');
-            if (report) {
-                logger.info('Removing the failed job report');
-                await reportsManager.failReport(report);
-            }
+        if (job.enabled === false) {
+            logger.info(`Skipping job with id: ${job.id} as it's currently disabled`);
+            return;
         }
+        await runJob(job, configData);
     }, function () {
-        logger.info('Job: ' + jobId + ' completed.');
+        logger.info(`Job: ${job.id} completed.`);
     }, true);
-    cronJobs[jobId] = scheduledJob;
+    cronJobs[job.id] = scheduledJob;
 }
 
 async function validateWebhooksAssignment(webhookIds) {
@@ -355,4 +335,27 @@ async function getJobInternal(jobId) {
         logger.error(error, 'Error occurred trying to get job');
         throw error;
     }
+}
+
+async function failReport(report) {
+    if (!report) {
+        return;
+    }
+    logger.info('Removing the failed job report');
+    return reportsManager.failReport(report);
+}
+
+async function runJob(job, configData) {
+    let report;
+    try {
+        const latestDockerImage = await dockerHubConnector.getMostRecentRunnerTag();
+        const test = await testsManager.getTest(job.test_id);
+        report = await createReportForJob(test, job);
+        const jobSpecificPlatformRequest = await createJobRequest(job.id, report.report_id, job, latestDockerImage, configData);
+        await jobConnector.runJob(jobSpecificPlatformRequest, job);
+    } catch (error) {
+        logger.error({ id: job.id, error: error }, 'Unable to run scheduled job.');
+        await failReport(report);
+    }
+    return report;
 }

--- a/src/reports/models/database/sequelize/sequelizeConnector.js
+++ b/src/reports/models/database/sequelize/sequelizeConnector.js
@@ -133,10 +133,10 @@ async function updateReportBenchmark(testId, reportId, score, benchmarkData) {
     return res;
 }
 
-async function subscribeRunner(testId, reportId, runnerId) {
+async function subscribeRunner(testId, reportId, runnerId, phaseStatus = constants.SUBSCRIBER_INITIALIZING_STAGE) {
     const newSubscriber = {
         runner_id: runnerId,
-        phase_status: constants.SUBSCRIBER_INITIALIZING_STAGE
+        phase_status: phaseStatus
     };
 
     const report = client.model('report');

--- a/src/reports/models/reportsManager.js
+++ b/src/reports/models/reportsManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const httpContext = require('express-http-context');
+const uuid = require('uuid');
 
 const databaseConnector = require('./databaseConnector'),
     jobConnector = require('../../jobs/models/jobManager'),
@@ -139,6 +140,10 @@ module.exports.postReportDeprecated = async function (testId, reportBody) {
         reportBody.test_description, JSON.stringify(testConfiguration), job.notes, Date.now(), false);
     await databaseConnector.subscribeRunner(testId, reportBody.report_id, reportBody.runner_id, constants.SUBSCRIBER_INITIALIZING_STAGE);
     return reportBody;
+};
+
+module.exports.failReport = async function failReport(report) {
+    return databaseConnector.subscribeRunner(report.test_id, report.report_id, uuid.v4(), constants.SUBSCRIBER_FAILED_STAGE);
 };
 
 function getReportResponse(summaryRow, config) {

--- a/tests/unit-tests/jobs/models/jobManager-test.js
+++ b/tests/unit-tests/jobs/models/jobManager-test.js
@@ -623,8 +623,8 @@ describe('Manager tests', function () {
             return manager.createJob(jobBodyWithoutRampTo)
                 .catch(function (error) {
                     jobConnectorRunJobStub.callCount.should.eql(1);
-                    loggerErrorStub.callCount.should.eql(1);
-                    loggerErrorStub.args[0].should.eql([{ error: 'job creator error' }, 'Error occurred trying to create new job']);
+                    loggerErrorStub.callCount.should.eql(2);
+                    loggerErrorStub.args[1].should.eql([{ error: 'job creator error' }, 'Error occurred trying to create new job']);
                     error.should.eql({ error: 'job creator error' });
                 });
         });

--- a/tests/unit-tests/jobs/models/jobManager-test.js
+++ b/tests/unit-tests/jobs/models/jobManager-test.js
@@ -204,13 +204,13 @@ describe('Manager tests', function () {
                 },
                 getConfigValue: getConfigValueStub
             });
-            uuidStub.returns('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+            uuidStub.returns(JOB_ID);
         });
 
         it('Simple request with custom env vars, should save new job to databaseConnector, deploy the job and return the job id and the job configuration', async () => {
             const webhooks = [
                 {
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: TEST_ID,
                     name: 'dina',
                     url: 'dina@mail.com',
                     global: false
@@ -223,6 +223,7 @@ describe('Manager tests', function () {
                 }
             ];
             const jobBodyWithCustomEnvVars = {
+                id: JOB_ID,
                 test_id: TEST_ID,
                 arrival_rate: 1,
                 duration: 1,
@@ -237,8 +238,8 @@ describe('Manager tests', function () {
             jobConnectorRunJobStub.resolves({ id: 'report_id' });
             databaseConnectorInsertStub.resolves(jobBodyWithCustomEnvVars);
             const expectedResult = {
-                id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
-                test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                id: JOB_ID,
+                test_id: TEST_ID,
                 environment: 'test',
                 emails: ['dina@niv.eli'],
                 webhooks: webhooks.map(({ id }) => id),
@@ -264,9 +265,9 @@ describe('Manager tests', function () {
             postReportStub.callCount.should.eql(1);
             jobConnectorRunJobStub.callCount.should.eql(1);
             jobTemplateCreateJobRequestStub.args[0][3].should.containEql({
-                JOB_ID: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
+                JOB_ID: JOB_ID,
                 ENVIRONMENT: 'test',
-                TEST_ID: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                TEST_ID: TEST_ID,
                 PREDATOR_URL: 'localhost:80',
                 JOB_TYPE: 'load_test',
                 ARRIVAL_RATE: '1',
@@ -283,7 +284,7 @@ describe('Manager tests', function () {
         it('Simple request, should save new job to databaseConnector, deploy the job and return the job id and the job configuration', async () => {
             const webhooks = [
                 {
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: TEST_ID,
                     name: 'dina',
                     url: 'dina@mail.com',
                     global: false
@@ -309,9 +310,9 @@ describe('Manager tests', function () {
             jobConnectorRunJobStub.resolves({});
             databaseConnectorInsertStub.resolves(jobBodyWithoutCron);
             const expectedResult = {
-                id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
+                id: JOB_ID,
                 ramp_to: '1',
-                test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                test_id: TEST_ID,
                 environment: 'test',
                 emails: ['dina@niv.eli'],
                 webhooks: webhooks.map(({ id }) => id),
@@ -329,7 +330,7 @@ describe('Manager tests', function () {
         it('Simple request, with parallelism, should save new job to databaseConnector, deploy the job and return the job id and the job configuration', async () => {
             const webhooks = [
                 {
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: TEST_ID,
                     name: 'dina',
                     url: 'dina@mail.com',
                     global: false
@@ -357,9 +358,9 @@ describe('Manager tests', function () {
             jobConnectorRunJobStub.resolves({});
             databaseConnectorInsertStub.resolves(jobBodyWithParallelismThatSplitsNicely);
             const expectedResult = {
-                id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
+                id: JOB_ID,
                 ramp_to: '150',
-                test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                test_id: TEST_ID,
                 environment: 'test',
                 emails: ['dina@niv.eli'],
                 parallelism: 3,
@@ -394,7 +395,7 @@ describe('Manager tests', function () {
         it('Simple request, with parallelism, and arrival rate splits with decimal point, should round up', async () => {
             const webhooks = [
                 {
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: TEST_ID,
                     name: 'dina',
                     url: 'dina@mail.com',
                     global: false
@@ -422,9 +423,9 @@ describe('Manager tests', function () {
             jobConnectorRunJobStub.resolves({});
             databaseConnectorInsertStub.resolves(jobBodyWithParallelismThatSplitsWithDecimal);
             const expectedResult = {
-                id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
+                id: JOB_ID,
                 ramp_to: '150',
-                test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                test_id: TEST_ID,
                 environment: 'test',
                 emails: ['dina@niv.eli'],
                 parallelism: 20,
@@ -459,7 +460,7 @@ describe('Manager tests', function () {
         it('Simple request without ramp to, should save new job to databaseConnector, deploy the job and return the job id and the job configuration', async () => {
             const webhooks = [
                 {
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: TEST_ID,
                     name: 'dina',
                     url: 'dina@mail.com',
                     global: false
@@ -483,8 +484,8 @@ describe('Manager tests', function () {
             jobConnectorRunJobStub.resolves({ id: 'report_id' });
             databaseConnectorInsertStub.resolves(jobBodyWithoutRampTo);
             const expectedResult = {
-                id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
-                test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                id: JOB_ID,
+                test_id: TEST_ID,
                 environment: 'test',
                 emails: ['dina@niv.eli'],
                 webhooks: webhooks.map(({ id }) => id),
@@ -507,17 +508,17 @@ describe('Manager tests', function () {
                 run_immediately: true,
                 emails: ['dina@niv.eli'],
                 environment: 'test',
-                webhooks: ['5a9eee73-cf56-47aa-ac77-fad59e961aaa', '5a9eee73-cf56-47aa-ac77-fad59e961aab'],
+                webhooks: [TEST_ID, '5a9eee73-cf56-47aa-ac77-fad59e961aab'],
                 enabled: false
             };
             jobConnectorRunJobStub.resolves({ id: 'report_id' });
             databaseConnectorInsertStub.resolves(jobBodyWithEnabledFalse);
             const expectedResult = {
-                id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
-                test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                id: JOB_ID,
+                test_id: TEST_ID,
                 environment: 'test',
                 emails: ['dina@niv.eli'],
-                webhooks: ['5a9eee73-cf56-47aa-ac77-fad59e961aaa', '5a9eee73-cf56-47aa-ac77-fad59e961aab'],
+                webhooks: [TEST_ID, '5a9eee73-cf56-47aa-ac77-fad59e961aab'],
                 arrival_rate: 1,
                 duration: 1,
                 enabled: false
@@ -532,7 +533,7 @@ describe('Manager tests', function () {
         it('Fail to save job to databaseConnector', function () {
             const webhooks = [
                 {
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: TEST_ID,
                     name: 'dina',
                     url: 'dina@mail.com',
                     global: false
@@ -595,7 +596,7 @@ describe('Manager tests', function () {
         it('Fail to create a job', function () {
             const webhooks = [
                 {
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: TEST_ID,
                     name: 'dina',
                     url: 'dina@mail.com',
                     global: false
@@ -636,7 +637,7 @@ describe('Manager tests', function () {
             it('Validate response', function () {
                 const webhooks = [
                     {
-                        id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                        id: TEST_ID,
                         name: 'dina',
                         url: 'dina@mail.com',
                         global: false
@@ -650,7 +651,7 @@ describe('Manager tests', function () {
                 ];
                 const jobBodyWithCron = {
                     test_id: TEST_ID,
-                    id: TEST_ID,
+                    id: JOB_ID,
                     arrival_rate: 1,
                     duration: 1,
                     enabled: true,
@@ -667,8 +668,8 @@ describe('Manager tests', function () {
                     cron_expression: '* * * * * *',
                     enabled: true,
                     ramp_to: '1',
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
-                    test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: JOB_ID,
+                    test_id: TEST_ID,
                     environment: 'test',
                     emails: ['dina@niv.eli'],
                     webhooks: webhooks.map(({ id }) => id),
@@ -692,7 +693,7 @@ describe('Manager tests', function () {
                 this.timeout(5000);
                 setTimeout(async () => {
                     try {
-                        await manager.deleteJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+                        await manager.deleteJob(JOB_ID);
                         loggerErrorStub.callCount.should.eql(0);
                         done();
                     } catch (error) {
@@ -710,7 +711,7 @@ describe('Manager tests', function () {
             it('Validate response', function () {
                 const webhooks = [
                     {
-                        id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                        id: TEST_ID,
                         name: 'dina',
                         url: 'dina@mail.com',
                         global: false
@@ -724,7 +725,7 @@ describe('Manager tests', function () {
                 ];
                 const jobBodyWithCron = {
                     test_id: TEST_ID,
-                    id: TEST_ID,
+                    id: JOB_ID,
                     arrival_rate: 1,
                     duration: 1,
                     cron_expression: '* * * * * *',
@@ -739,8 +740,8 @@ describe('Manager tests', function () {
                     enabled: false,
                     cron_expression: '* * * * * *',
                     ramp_to: '1',
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
-                    test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: JOB_ID,
+                    test_id: TEST_ID,
                     environment: 'test',
                     emails: ['dina@niv.eli'],
                     webhooks: webhooks.map(({ id }) => id),
@@ -766,7 +767,7 @@ describe('Manager tests', function () {
                 this.timeout(5000);
                 setTimeout(async () => {
                     try {
-                        await manager.deleteJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+                        await manager.deleteJob(JOB_ID);
                         loggerInfoStub.args[0][0].should.eql('Skipping job with id: 5a9eee73-cf56-47aa-ac77-fad59e961aaf as it\'s currently disabled');
                         loggerErrorStub.callCount.should.eql(0);
                         done();
@@ -785,7 +786,7 @@ describe('Manager tests', function () {
             it('Validate response', function () {
                 const webhooks = [
                     {
-                        id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                        id: TEST_ID,
                         name: 'dina',
                         url: 'dina@mail.com',
                         global: false
@@ -799,7 +800,7 @@ describe('Manager tests', function () {
                 ];
                 const jobBodyWithCron = {
                     test_id: TEST_ID,
-                    id: TEST_ID,
+                    id: JOB_ID,
                     arrival_rate: 1,
                     duration: 1,
                     enabled: true,
@@ -817,8 +818,8 @@ describe('Manager tests', function () {
                     enabled: true,
                     cron_expression: '* * * * * *',
                     ramp_to: '1',
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
-                    test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: JOB_ID,
+                    test_id: TEST_ID,
                     environment: 'test',
                     emails: ['dina@niv.eli'],
                     webhooks: webhooks.map(({ id }) => id),
@@ -839,7 +840,7 @@ describe('Manager tests', function () {
                 this.timeout(5000);
                 setTimeout(async () => {
                     try {
-                        await manager.deleteJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+                        await manager.deleteJob(JOB_ID);
                         jobConnectorRunJobStub.callCount.should.eql(3);
                         done();
                     } catch (error) {
@@ -853,7 +854,7 @@ describe('Manager tests', function () {
             it('Validate response', function () {
                 const webhooks = [
                     {
-                        id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                        id: TEST_ID,
                         name: 'dina',
                         url: 'dina@mail.com',
                         global: false
@@ -867,6 +868,7 @@ describe('Manager tests', function () {
                 ];
                 const jobBodyWithCronNotImmediately = {
                     test_id: TEST_ID,
+                    id: JOB_ID,
                     arrival_rate: 1,
                     duration: 1,
                     cron_expression: '',
@@ -885,8 +887,8 @@ describe('Manager tests', function () {
                 const expectedResult = {
                     cron_expression: date.getSeconds() + ' * * * * *',
                     ramp_to: '1',
-                    id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
-                    test_id: '5a9eee73-cf56-47aa-ac77-fad59e961aaa',
+                    id: JOB_ID,
+                    test_id: TEST_ID,
                     environment: 'test',
                     emails: ['dina@niv.eli'],
                     webhooks: webhooks.map(({ id }) => id),
@@ -919,7 +921,7 @@ describe('Manager tests', function () {
                 this.timeout(6000);
                 setTimeout(async () => {
                     try {
-                        await manager.deleteJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+                        await manager.deleteJob(JOB_ID);
                         done();
                     } catch (error) {
                         done(new Error(error));
@@ -943,7 +945,7 @@ describe('Manager tests', function () {
                 getConfigValue: getConfigValueStub
 
             });
-            uuidStub.returns('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+            uuidStub.returns(JOB_ID);
         });
 
         it('Should update job successfully', async function () {
@@ -963,7 +965,7 @@ describe('Manager tests', function () {
             ];
             const jobBodyWithCron = {
                 test_id: TEST_ID,
-                id: TEST_ID,
+                id: JOB_ID,
                 arrival_rate: 1,
                 duration: 1,
                 enabled: true,
@@ -978,7 +980,7 @@ describe('Manager tests', function () {
             databaseConnectorInsertStub.resolves(jobBodyWithCron);
             databaseConnectorUpdateJobStub.resolves({});
             databaseConnectorGetSingleJobStub.resolves([{
-                id: '5a9eee73-cf56-47aa-ac77-fad59e961aaf',
+                id: JOB_ID,
                 test_id: 'secondId',
                 environment: 'test',
                 arrival_rate: 1,
@@ -993,17 +995,17 @@ describe('Manager tests', function () {
             postReportStub.resolves({ report_id: Date.now() });
 
             await manager.createJob(jobBodyWithCron);
-            await manager.updateJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf', { cron_expression: '20 * * * *' });
+            await manager.updateJob(JOB_ID, { cron_expression: '20 * * * *' });
 
             loggerInfoStub.callCount.should.eql(4);
             manager.__get__('cronJobs')[JOB_ID].cronTime.source.should.eql('20 * * * *');
-            await manager.deleteJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+            await manager.deleteJob(JOB_ID);
         });
 
         it('Updating data in databaseConnector fails', async function () {
             const jobBodyWithCron = {
                 test_id: TEST_ID,
-                id: TEST_ID,
+                id: JOB_ID,
                 arrival_rate: 1,
                 duration: 1,
                 enabled: true,
@@ -1022,13 +1024,13 @@ describe('Manager tests', function () {
                 postReportStub.resolves({ report_id: Date.now() });
 
                 await manager.createJob(jobBodyWithCron);
-                await manager.updateJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf', { cron_expression: '20 * * * *' });
+                await manager.updateJob(JOB_ID, { cron_expression: '20 * * * *' });
             } catch (error) {
                 error.should.eql({ error: 'error' });
                 loggerInfoStub.callCount.should.eql(2);
                 loggerErrorStub.callCount.should.eql(1);
                 manager.__get__('cronJobs')[JOB_ID].cronTime.source.should.eql('* * * * * *');
-                await manager.deleteJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+                await manager.deleteJob(JOB_ID);
             }
         });
     });
@@ -1037,7 +1039,7 @@ describe('Manager tests', function () {
         it('Deletes an existing job', async function () {
             const jobBodyWithCron = {
                 test_id: TEST_ID,
-                id: TEST_ID,
+                id: JOB_ID,
                 arrival_rate: 1,
                 duration: 1,
                 enabled: true,
@@ -1060,7 +1062,7 @@ describe('Manager tests', function () {
                 getConfigValue: getConfigValueStub
 
             });
-            uuidStub.returns('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+            uuidStub.returns(JOB_ID);
             jobConnectorRunJobStub.resolves({});
             databaseConnectorInsertStub.resolves(jobBodyWithCron);
             databaseConnectorDeleteStub.resolves({});
@@ -1068,7 +1070,7 @@ describe('Manager tests', function () {
             postReportStub.resolves({ report_id: Date.now() });
 
             await manager.createJob(jobBodyWithCron);
-            await manager.deleteJob('5a9eee73-cf56-47aa-ac77-fad59e961aaf');
+            await manager.deleteJob(JOB_ID);
             databaseConnectorDeleteStub.callCount.should.eql(1);
             loggerInfoStub.args[2].should.eql(['Job: 5a9eee73-cf56-47aa-ac77-fad59e961aaf completed.']);
         });

--- a/tests/unit-tests/reporter/models/reportsManager-test.js
+++ b/tests/unit-tests/reporter/models/reportsManager-test.js
@@ -15,6 +15,7 @@ const notifier = require('../../../../src/reports/models/notifier');
 const constants = require('../../../../src/reports/utils/constants');
 const configHandler = require('../../../../src/configManager/models/configHandler');
 const basicTest = require('../../../testExamples/Basic_test.json');
+const { expect } = require('chai');
 
 let manager;
 let statsManager;
@@ -740,6 +741,21 @@ describe('Reports manager tests', function () {
             updateReportBenchmarkStub.callCount.should.eql(0);
 
             should(getBenchmarkStub.args).eql([['test_id']]);
+        });
+    });
+    describe('#failReport', function() {
+        it('should call the connector with status failed', async function() {
+            const reportId = uuid.v4();
+            const testId = uuid.v4();
+
+            databaseSubscribeRunnerStub.resolves();
+
+            manager.failReport({ report_id: reportId, test_id: testId });
+
+            expect(databaseSubscribeRunnerStub.calledOnce).to.be.equal(true);
+            expect(databaseSubscribeRunnerStub.args[0][0]).to.be.equal(testId);
+            expect(databaseSubscribeRunnerStub.args[0][1]).to.be.equal(reportId);
+            expect(databaseSubscribeRunnerStub.args[0][3]).to.be.equal(constants.SUBSCRIBER_FAILED_STAGE);
         });
     });
 });


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |


Further  information:
@NivLipetz @enudler any idea how to create an integration test for that, in integration I can't retrieve the report_id, I was thinking about using `GET /last_reports`, wdyt?
