### PR TITLE
fix: job-started streaming message missing job_id

### DIFF
--- a/src/jobs/models/jobManager.js
+++ b/src/jobs/models/jobManager.js
@@ -73,7 +73,12 @@ module.exports.createJob = async (job) => {
         }
         logger.info(`Job ${jobId} deployed successfully`);
         const jobResponse = createResponse(jobId, job, report);
-        streamingManager.produce({}, STREAMING_EVENT_TYPES.JOB_CREATED, jobResponse);
+        const streamingResource = {
+            job_id: jobResponse.id,
+            job_type: jobResponse.type,
+            ...jobResponse
+        };
+        streamingManager.produce({}, STREAMING_EVENT_TYPES.JOB_CREATED, streamingResource);
 
         return jobResponse;
     } catch (error) {
@@ -284,7 +289,12 @@ function addCron(job, cronExpression, configData) {
         }
         const report = await runJob(job, configData);
         const jobResponse = createResponse(job.id, job, report);
-        streamingManager.produce({}, STREAMING_EVENT_TYPES.JOB_CREATED, jobResponse);
+        const streamingResource = {
+            job_id: jobResponse.id,
+            job_type: jobResponse.type,
+            ...jobResponse
+        };
+        streamingManager.produce({}, STREAMING_EVENT_TYPES.JOB_CREATED, streamingResource);
     }, function () {
         logger.info(`Job: ${job.id} completed.`);
     }, true);

--- a/tests/integration-tests-with-streaming/dockerFullFlow-test.js
+++ b/tests/integration-tests-with-streaming/dockerFullFlow-test.js
@@ -103,7 +103,9 @@ describe('Create job specific docker tests', async function () {
                         should(valuePublished.event).eql('job-created');
                         should(valuePublished.resource).containEql({
                             test_id: testId,
+                            job_id: jobId,
                             report_id: reportId,
+                            job_type: 'load_test',
                             arrival_rate: 2,
                             notes: 'streaming notes',
                             duration: 1
@@ -156,7 +158,9 @@ describe('Create job specific docker tests', async function () {
                         should(valuePublished.event).eql('job-created');
                         should(valuePublished.resource).containEql({
                             test_id: testId,
+                            job_id: jobId,
                             report_id: reportId,
+                            job_type: 'load_test',
                             arrival_rate: 2,
                             notes: 'streaming notes',
                             duration: 1
@@ -215,7 +219,9 @@ describe('Create job specific docker tests', async function () {
                         should(valuePublished.event).eql('job-created');
                         should(valuePublished.resource).containEql({
                             test_id: testId,
+                            job_id: jobId,
                             report_id: reportId,
+                            job_type: 'load_test',
                             arrival_rate: 2,
                             notes: 'streaming notes',
                             duration: 1


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                      |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |

