### PR TITLE
fix: produce job to streaming platform only when started run

### DIFF
--- a/tests/integration-tests-with-streaming/run.sh
+++ b/tests/integration-tests-with-streaming/run.sh
@@ -16,4 +16,4 @@ echo Running integration tests with "$DATABASE_TYPE" db and "$JOB_PLATFORM" inte
 source $CURR_DIR/tests/configurations/"$DATABASE_TYPE"Configuration.sh
 source $CURR_DIR/tests/configurations/"$JOB_PLATFORM"Configuration.sh
 source $CURR_DIR/tests/configurations/"$STREAMING_PLATFORM"Configuration.sh
-node_modules/.bin/_mocha $CURR_DIR/tests/integration-tests-with-streaming --recursive --timeout=30000 --retries=2 --exit
+node_modules/.bin/_mocha $CURR_DIR/tests/integration-tests-with-streaming --recursive --timeout=40000 --retries=2 --exit

--- a/tests/integration-tests/run.sh
+++ b/tests/integration-tests/run.sh
@@ -16,4 +16,4 @@ fi
 echo Running integration tests with "$DATABASE_TYPE" db and "$JOB_PLATFORM" integration
 source $CURR_DIR/tests/configurations/"$DATABASE_TYPE"Configuration.sh
 source $CURR_DIR/tests/configurations/"$JOB_PLATFORM"Configuration.sh
-node_modules/.bin/_mocha $CURR_DIR/tests/integration-tests --recursive --timeout=30000 --retries=2 --exit
+node_modules/.bin/_mocha $CURR_DIR/tests/integration-tests --recursive --timeout=40000 --retries=2 --exit


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔/                                                                       |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   |✖                                                                        |
| Tests added     | ✖                                                                        |

