### PR TITLE
fix: success ratio in report pages shows too many decimals

### DIFF
--- a/ui/src/features/redux/selectors/reportsSelector.js
+++ b/ui/src/features/redux/selectors/reportsSelector.js
@@ -81,7 +81,7 @@ function buildAssertionsTable(assertionsTable, data) {
                 assertion: assertEntry[0],
                 fail: assertEntry[1].fail,
                 success: assertEntry[1].success,
-                success_ratio: `${successRatio * 100}%`,
+                success_ratio: `${(successRatio === 1) ? (successRatio * 100) : (successRatio * 100).toFixed(2)}%`,
                 failure_responses: Object.entries(assertEntry[1].failureResponses).map((entry) => ({
                     name: entry[0],
                     value: entry[1]


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |

Related issues: #565

Further  information:
<!--
Here you can provide more information regarding any of the questions written above.
In addition, you can add screenshots, ask the maintainers questions.
-->

<img width="569" alt="Screen Shot 2021-02-18 at 17 29 59" src="https://user-images.githubusercontent.com/12823925/108327698-0e01b180-720f-11eb-8b27-bea7750b5805.png">
