### PR TITLE
WIP feat(files): get file by file name

### DIFF
--- a/docs/devguide/docs/swagger-docs.yaml
+++ b/docs/devguide/docs/swagger-docs.yaml
@@ -1853,6 +1853,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/upload_file_response'
+  '/v1/files/name/{file_name}':
+    parameters:
+      - $ref: '#/components/parameters/context_id'
+    get:
+      operationId: retrieve-file
+      tags:
+        - Files
+      summary: Download file
+      description: Retrieve a specific file.
+      parameters:
+        - in: path
+          name: file_name
+          description: The name of file to download
+          required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/upload_file_response'
   '/v1/files/{file_id}/metadata':
     parameters:
       - $ref: '#/components/parameters/context_id'

--- a/docs/openapi3.yaml
+++ b/docs/openapi3.yaml
@@ -1853,6 +1853,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/upload_file_response'
+  '/v1/files/name/{file_name}':
+    parameters:
+      - $ref: '#/components/parameters/context_id'
+    get:
+      operationId: retrieve-file
+      tags:
+        - Files
+      summary: Download file
+      description: Retrieve a specific file.
+      parameters:
+        - in: path
+          name: file_name
+          description: The name of file to download
+          required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/upload_file_response'
   '/v1/files/{file_id}/metadata':
     parameters:
       - $ref: '#/components/parameters/context_id'

--- a/src/files/controllers/filesController.js
+++ b/src/files/controllers/filesController.js
@@ -5,12 +5,30 @@ const fileManager = require('../models/fileManager');
 module.exports = {
     getFile,
     saveFile,
-    getFileMetadata
+    getFileMetadata,
+    getFileByName
 };
 
 async function getFile(req, res, next) {
     try {
         const fileData = await fileManager.getFile(req.params.file_id, true);
+
+        const fileContents = Buffer.from(fileData.content, 'base64');
+        const readStream = new stream.PassThrough();
+        readStream.end(fileContents);
+
+        res.set('Content-disposition', 'attachment; filename=' + fileData.filename);
+        res.set('Content-Type', 'text/plain');
+
+        readStream.pipe(res);
+    } catch (err) {
+        return next(err);
+    }
+}
+
+async function getFileByName(req, res, next) {
+    try {
+        const fileData = await fileManager.getFileByName(req.params.file_name, true);
 
         const fileContents = Buffer.from(fileData.content, 'base64');
         const readStream = new stream.PassThrough();

--- a/src/files/models/database.js
+++ b/src/files/models/database.js
@@ -4,7 +4,8 @@ const databaseConnector = sequelizeConnector;
 
 module.exports = {
     saveFile,
-    getFile
+    getFile,
+    getFileByName
 };
 
 async function saveFile(id, fileName, fileContent, contextId) {
@@ -12,4 +13,8 @@ async function saveFile(id, fileName, fileContent, contextId) {
 }
 async function getFile(id, isIncludeContent, contextId) {
     return databaseConnector.getFile(id, isIncludeContent, contextId);
+}
+
+async function getFileByName(name, isIncludeContent, contextId) {
+    return databaseConnector.getFileByName(name, isIncludeContent, contextId);
 }

--- a/src/files/models/database/sequelize/sequelizeConnector.js
+++ b/src/files/models/database/sequelize/sequelizeConnector.js
@@ -2,6 +2,7 @@ const Sequelize = require('sequelize');
 module.exports = {
     init,
     getFile,
+    getFileByName,
     saveFile
 };
 
@@ -50,6 +51,25 @@ async function getFile(id, isIncludeContent, contextId) {
     const options = {
         attributes: { exclude: ['updated_at', 'created_at'] },
         where: { id }
+    };
+
+    if (!isIncludeContent) {
+        options.attributes.exclude.push('file');
+    }
+
+    if (contextId) {
+        options.where.context_id = contextId;
+    }
+
+    const dbResult = await fileClient.findOne(options);
+    return dbResult;
+}
+
+async function getFileByName(name, isIncludeContent, contextId) {
+    const fileClient = client.model('file');
+    const options = {
+        attributes: { exclude: ['updated_at', 'created_at'] },
+        where: { name }
     };
 
     if (!isIncludeContent) {

--- a/src/files/models/fileManager.js
+++ b/src/files/models/fileManager.js
@@ -7,13 +7,31 @@ const database = require('./database'),
 
 module.exports = {
     saveFile,
-    getFile
+    getFile,
+    getFileByName
 };
 
 async function getFile(fileId, isIncludeContent) {
     const contextId = httpContext.get(CONTEXT_ID);
 
     const file = await database.getFile(fileId, isIncludeContent, contextId);
+    if (file) {
+        return {
+            id: file.id,
+            filename: file.name,
+            content: file.file
+        };
+    } else {
+        const error = new Error(ERROR_MESSAGES.NOT_FOUND);
+        error.statusCode = 404;
+        throw error;
+    }
+}
+
+async function getFileByName(fileName, isIncludeContent) {
+    const contextId = httpContext.get(CONTEXT_ID);
+
+    const file = await database.getFileByName(fileName, isIncludeContent, contextId);
     if (file) {
         return {
             id: file.id,

--- a/src/files/routes/filesRoute.js
+++ b/src/files/routes/filesRoute.js
@@ -8,5 +8,6 @@ const swaggerValidator = require('express-ajv-swagger-validation');
 router.post('/', filesController.saveFile);
 router.get('/:file_id', swaggerValidator.validate, filesController.getFile);
 router.get('/:file_id/metadata', swaggerValidator.validate, filesController.getFileMetadata);
+router.get('/name/:file_name', swaggerValidator.validate, filesController.getFileByName);
 
 module.exports = router;


### PR DESCRIPTION
This is a work in progress to add a new API that allows you to get a file by filename rather than UUID. 

The use case for this is that we have API tests that perform multipart/form-data requests that upload a file to our application and currently Predator runners do not have the capability to pull down stored files in the predator service to use in their tests in a reproducible manner. This API will allow us to add a processor that can pull the file we want to upload (by file name) into the predator runner and attach it to the request we are making to our application.

WIP: This just adds the API but does not add any of the tests needed thus far.

I considered adding a where clause on the current get file API but after trying it out felt it made more sense to be its own API. Currently, I have only performed some basic sanity checks and have not tested edge cases such as special characters etc
