### PR TITLE
fix: round up the values of latency on report pages.

### DIFF
--- a/ui/src/features/redux/selectors/reportsSelector.js
+++ b/ui/src/features/redux/selectors/reportsSelector.js
@@ -120,9 +120,9 @@ function buildAggregateReportData(reports, withPrefix, startFromZeroTime, lastBe
             const timeMills = time.getTime();
             latencyGraph.push({
                 name: `${dateFormat(time, 'h:MM:ss')}`,
-                [`${prefix}median`]: latency.median,
-                [`${prefix}p95`]: latency.p95,
-                [`${prefix}p99`]: latency.p99,
+                [`${prefix}median`]: latency.median.toFixed(),
+                [`${prefix}p95`]: latency.p95.toFixed(),
+                [`${prefix}p99`]: latency.p99.toFixed(),
                 ...lastBenchmark.latency,
                 timeMills
             });


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     |✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |

Related issues: #571
Closes #571 

Further  information:
<!--
Here you can provide more information regarding any of the questions written above.
In addition, you can add screenshots, ask the maintainers questions.
-->
<img width="101" alt="Screen Shot 2021-03-28 at 17 42 05" src="https://user-images.githubusercontent.com/12823925/112747362-e7921b80-8fef-11eb-9ae9-9c438b232ec5.png">
