### PR TITLE
fix: adjust experiments start_after to be in seconds -api

### DIFF
--- a/docs/openapi3.yaml
+++ b/docs/openapi3.yaml
@@ -3282,7 +3282,7 @@ components:
             type: string
           start_after:
             type: number
-            description: time in milliseconds in which the experiment starts after job started
+            description: time in seconds in which the experiment starts after job started
     report_experiments:
       description: An array of objects that describe experiments to run during the job running, and timing
       type: array

--- a/tests/integration-tests/jobs/createJobDocker-test.js
+++ b/tests/integration-tests/jobs/createJobDocker-test.js
@@ -177,11 +177,11 @@ describe('Create job specific docker tests', async function () {
                         arrival_rate: 1,
                         parallelism: 2,
                         type: 'load_test',
-                        duration: 1,
+                        duration: 3,
                         experiments: [
                             {
                                 experiment_id: '1234',
-                                start_after: 5000
+                                start_after: 1
                             }
                         ],
                         environment: 'test',

--- a/tests/integration-tests/jobs/createJobFargate-test.js
+++ b/tests/integration-tests/jobs/createJobFargate-test.js
@@ -184,11 +184,11 @@ describe('Create job specific aws fargate tests', async function () {
                         arrival_rate: 1,
                         parallelism: 2,
                         type: 'load_test',
-                        duration: 1,
+                        duration: 3,
                         experiments: [
                             {
                                 experiment_id: '1234',
-                                start_after: 5000
+                                start_after: 1
                             }
                         ],
                         environment: 'test',

--- a/tests/integration-tests/jobs/createJobKubernetes-test.js
+++ b/tests/integration-tests/jobs/createJobKubernetes-test.js
@@ -162,7 +162,7 @@ describe('Create job specific kubernetes tests', async function () {
                         const jobBody = {
                             test_id: testId,
                             arrival_rate: 1,
-                            duration: 1,
+                            duration: 2,
                             environment: 'test',
                             run_immediately: true,
                             type: 'load_test',
@@ -173,7 +173,7 @@ describe('Create job specific kubernetes tests', async function () {
                                 },
                                 {
                                     experiment_id: chaosExperimentId,
-                                    start_after: 5000
+                                    start_after: 1
                                 }
                             ]
                         };
@@ -191,7 +191,7 @@ describe('Create job specific kubernetes tests', async function () {
                         const jobBody = {
                             test_id: testId,
                             arrival_count: 1,
-                            duration: 1,
+                            duration: 2,
                             environment: 'test',
                             run_immediately: false,
                             cron_expression: '* 10 * * * *',
@@ -199,7 +199,7 @@ describe('Create job specific kubernetes tests', async function () {
                             experiments: [
                                 {
                                     experiment_id: chaosExperimentId,
-                                    start_after: 5000
+                                    start_after: 1
                                 }
                             ]
                         };
@@ -264,7 +264,7 @@ describe('Create job specific kubernetes tests', async function () {
                         const jobBody = {
                             test_id: testId,
                             arrival_rate: 1,
-                            duration: 1,
+                            duration: 2,
                             environment: 'test',
                             run_immediately: true,
                             type: 'load_test',
@@ -275,7 +275,7 @@ describe('Create job specific kubernetes tests', async function () {
                                 },
                                 {
                                     experiment_id: chaosExperimentId,
-                                    start_after: 2
+                                    start_after: 1
                                 }
                             ]
                         };
@@ -1058,7 +1058,7 @@ describe('Create job specific kubernetes tests', async function () {
                             experiments: [
                                 {
                                     experiment_id: uuid.v4(),
-                                    start_after: 5000
+                                    start_after: 0
                                 }
                             ]
                         };

--- a/tests/integration-tests/jobs/createJobMetronome-test.js
+++ b/tests/integration-tests/jobs/createJobMetronome-test.js
@@ -212,11 +212,11 @@ describe('Create job specific metronome tests', async function () {
                         arrival_rate: 1,
                         parallelism: 2,
                         type: 'load_test',
-                        duration: 1,
+                        duration: 120,
                         experiments: [
                             {
                                 experiment_id: '1234',
-                                start_after: 5000
+                                start_after: 60
                             }
                         ],
                         environment: 'test',

--- a/tests/integration-tests/reports/reportsApi-test.js
+++ b/tests/integration-tests/reports/reportsApi-test.js
@@ -97,7 +97,7 @@ const jobPlatform = process.env.JOB_PLATFORM;
                     const job = {
                         test_id: testId,
                         arrival_rate: 1,
-                        duration: 1,
+                        duration: 3,
                         environment: 'test',
                         run_immediately: true,
                         type: 'load_test',
@@ -105,12 +105,12 @@ const jobPlatform = process.env.JOB_PLATFORM;
                         emails: [],
                         experiments: [
                             {
-                                start_after: 0,
+                                start_after: 1,
                                 experiment_id: chaosExperimentsInserted[0].body.id,
                                 experiment_name: chaosExperimentsInserted[0].body.name
                             },
                             {
-                                start_after: 2000,
+                                start_after: 2,
                                 experiment_id: chaosExperimentsInserted[1].body.id,
                                 experiment_name: chaosExperimentsInserted[1].body.name
                             }

--- a/tests/unit-tests/jobs/helpers/jobVerifier-test.js
+++ b/tests/unit-tests/jobs/helpers/jobVerifier-test.js
@@ -203,14 +203,14 @@ describe('Jobs verifier tests', function () {
         });
         it('if chaos experiments mentioned in the job exist, should pass', async () => {
             configHandlerStub.withArgs(consts.CONFIG.JOB_PLATFORM).resolves('KUBERNETES');
-            req = { body: { run_immediately: true, cron_expression: '* * * * *', enabled: true, experiments: [{ experiment_id: '1234', start_after: 1000 }] } };
+            req = { body: { run_immediately: true, cron_expression: '* * * * *', enabled: true, experiments: [{ experiment_id: '1234', start_after: 60 }] } };
             getChaosExperimentsByIdsStub.resolves([{ id: '1234' }]);
             await jobVerifier.verifyExperimentsExist(req, res, nextStub);
             should(nextStub.args[0][0]).eql(undefined);
         });
         it('if chaos experiments mentioned in the job do not exist, should fail', async () => {
             configHandlerStub.withArgs(consts.CONFIG.JOB_PLATFORM).resolves('KUBERNETES');
-            req = { body: { run_immediately: true, cron_expression: '* * * * *', enabled: true, experiments: [{ experiment_id: '1234', start_after: 1000 }] } };
+            req = { body: { run_immediately: true, cron_expression: '* * * * *', enabled: true, experiments: [{ experiment_id: '1234', start_after: 60 }] } };
             getChaosExperimentsByIdsStub.resolves([]);
             await jobVerifier.verifyExperimentsExist(req, res, nextStub);
             should(nextStub.args[0][0].message).eql('One or more chaos experiments are not configured. Job can not be created');
@@ -218,7 +218,7 @@ describe('Jobs verifier tests', function () {
         });
         it('if job platform is not KUBERNETES and  job has experiments job does not have experiments, should pass', async () => {
             configHandlerStub.withArgs(consts.CONFIG.JOB_PLATFORM).resolves('DOCKER');
-            req = { body: { run_immediately: true, cron_expression: '* * * * *', enabled: false, experiments: [{ experiment_id: '1234', start_after: 1000 }] } };
+            req = { body: { run_immediately: true, cron_expression: '* * * * *', enabled: false, experiments: [{ experiment_id: '1234', start_after: 60 }] } };
             await jobVerifier.verifyExperimentsExist(req, res, nextStub);
             should(nextStub.args[0][0].message).eql('Chaos experiment is supported only in kubernetes jobs');
             should(nextStub.args[0][0].statusCode).eql(400);

--- a/tests/unit-tests/jobs/models/jobManager-test.js
+++ b/tests/unit-tests/jobs/models/jobManager-test.js
@@ -226,7 +226,7 @@ describe('Manager jobs', function () {
                 id: JOB_ID,
                 test_id: TEST_ID,
                 arrival_rate: 1,
-                duration: 1,
+                duration: 120,
                 run_immediately: true,
                 type: 'load_test',
                 emails: ['dina@niv.eli'],
@@ -234,7 +234,7 @@ describe('Manager jobs', function () {
                 experiments: [
                     {
                         experiment_id: '1234',
-                        start_after: 5000
+                        start_after: 60
                     }
                 ],
                 webhooks: webhooks.map(({ id }) => id),
@@ -250,13 +250,13 @@ describe('Manager jobs', function () {
                 emails: ['dina@niv.eli'],
                 webhooks: webhooks.map(({ id }) => id),
                 arrival_rate: 1,
-                duration: 1,
+                duration: 120,
                 max_virtual_users: 100,
                 enabled: true,
                 experiments: [
                     {
                         experiment_id: '1234',
-                        start_after: 5000
+                        start_after: 60
                     }
                 ],
                 custom_env_vars: {
@@ -285,7 +285,7 @@ describe('Manager jobs', function () {
                 ARRIVAL_RATE: '1',
                 REPORT_ID: reportId,
                 PREDATOR_VERSION,
-                DURATION: '1',
+                DURATION: '120',
                 CUSTOM_KEY1: 'A',
                 CUSTOM_KEY2: 'B'
             });
@@ -979,14 +979,14 @@ describe('Manager jobs', function () {
                 test_id: TEST_ID,
                 id: JOB_ID,
                 arrival_rate: 1,
-                duration: 1,
+                duration: 120,
                 enabled: true,
                 cron_expression: '* * * * * *',
                 run_immediately: false,
                 experiments: [
                     {
                         experiment_id: '1234',
-                        start_after: 5000
+                        start_after: 60
                     }
                 ],
                 emails: ['dina@niv.eli'],
@@ -1018,7 +1018,7 @@ describe('Manager jobs', function () {
                 experiments: [
                     {
                         experiment_id: '1234',
-                        start_after: 3000
+                        start_after: 60
                     }
                 ]
             });

--- a/tests/unit-tests/jobs/models/kubernetes/jobExperimentsHandler-test.js
+++ b/tests/unit-tests/jobs/models/kubernetes/jobExperimentsHandler-test.js
@@ -77,7 +77,7 @@ describe('Job experiments handler tests', function () {
             clock = sinon.useFakeTimers();
             clock.tick(1000);
             await jobExperimentHandler.setChaosExperimentsIfExist(jobId, jobExperiments);
-            clock.tick(3000);
+            clock.tick(60 * 1000 * 2);
             (experimentsManagerRunJobStub.callCount).should.eql(2);
             experimentsManagerRunJobStub.args[0][0].metadata.name.should.eql(`${firstExperimentName}-${experimentsManagerRunJobStub.args[0][2]}`);
             experimentsManagerGetStub.callCount.should.eql(1);

--- a/tests/unit-tests/jobs/models/kubernetes/jobExperimentsHandler-test.js
+++ b/tests/unit-tests/jobs/models/kubernetes/jobExperimentsHandler-test.js
@@ -66,11 +66,11 @@ describe('Job experiments handler tests', function () {
             const jobExperiments = [
                 {
                     experiment_id: firstExperiment.id,
-                    start_after: 1000
+                    start_after: 60
                 },
                 {
                     experiment_id: secondExperiment.id,
-                    start_after: 2000
+                    start_after: 120
                 }
             ];
             const jobId = uuid();
@@ -87,7 +87,7 @@ describe('Job experiments handler tests', function () {
             (experimentsManagerInsertStub.args[0][4] - experimentsManagerInsertStub.args[0][3]).should.eql(60000);
             experimentsManagerInsertStub.args[1][1].should.eql(jobId);
             experimentsManagerInsertStub.args[1][2].should.eql(secondExperiment.id);
-            (experimentsManagerInsertStub.args[1][3] - experimentsManagerInsertStub.args[0][3]).should.eql(1000);
+            (experimentsManagerInsertStub.args[1][3] - experimentsManagerInsertStub.args[0][3]).should.eql(60000);
         });
 
         it('set chaos experiments with same experiment in different times', async () => {
@@ -97,11 +97,11 @@ describe('Job experiments handler tests', function () {
             const jobExperiments = [
                 {
                     experiment_id: experiment.id,
-                    start_after: 1000
+                    start_after: 60
                 },
                 {
                     experiment_id: experiment.id,
-                    start_after: 2000
+                    start_after: 120
                 }
             ];
             const jobId = uuid();


### PR DESCRIPTION
[<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->](feat: assuming start_after is sent in seconds in the api - for runJob schedule calculate)

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                   |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                       |

