### PR TITLE
feat(config): add DATABASE_PORT support

### DIFF
--- a/docs/devguide/docs/configuration.md
+++ b/docs/devguide/docs/configuration.md
@@ -29,6 +29,7 @@ Below are variables Predator can be configured with.
 | DATABASE_TYPE        	| Database to integrate Predator with [Postgres, MySQL, MSSQL, SQLITE] 	| x                        	| SQLITE        	|
 | DATABASE_NAME        	| Database/Keyspace name                                                          	| x                        	|               	|
 | DATABASE_ADDRESS     	| Database address                                                                	| x                        	|               	|
+| DATABASE_PORT     	| Database port                                                                	| x                        	|               	|
 | DATABASE_USERNAME    	| Database username                                                               	| x                        	|               	|
 | DATABASE_PASSWORD    	| Database password                                                               	| x                        	|               	|
 

--- a/src/config/databaseConfig.js
+++ b/src/config/databaseConfig.js
@@ -2,6 +2,7 @@ const config = {
     type: (process.env.DATABASE_TYPE || 'SQLITE').toUpperCase(),
     name: process.env.DATABASE_NAME || 'predator',
     address: process.env.DATABASE_ADDRESS,
+    port: parseInt(process.env.DATABASE_PORT, 10) ?? 3306,
     username: process.env.DATABASE_USERNAME,
     password: process.env.DATABASE_PASSWORD,
     sqliteStorage: process.env.SQLITE_STORAGE || 'predator.sqlite'

--- a/src/config/databaseConfig.js
+++ b/src/config/databaseConfig.js
@@ -2,7 +2,7 @@ const config = {
     type: (process.env.DATABASE_TYPE || 'SQLITE').toUpperCase(),
     name: process.env.DATABASE_NAME || 'predator',
     address: process.env.DATABASE_ADDRESS,
-    port: parseInt(process.env.DATABASE_PORT, 10) ?? 3306,
+    port: parseInt(process.env.DATABASE_PORT, 10) || 3306,
     username: process.env.DATABASE_USERNAME,
     password: process.env.DATABASE_PASSWORD,
     sqliteStorage: process.env.SQLITE_STORAGE || 'predator.sqlite'

--- a/src/database/sequlize-handler/sequlize.js
+++ b/src/database/sequlize-handler/sequlize.js
@@ -46,6 +46,7 @@ async function createClient() {
         dialect: databaseConfig.type.toLowerCase(),
         logging: false,
         host: databaseConfig.address,
+        port: databaseConfig.port,
         define: {
             underscored: true,
             createdAt: 'created_at',


### PR DESCRIPTION
- Added DATABASE_PORT to database configuration
- Ensured proper handling using Nullish Coalescing (??) for fallback
- Updated `createClient` function to include port in Sequelize options
- Updated documentation

<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✔                                                                        |
| Tests added     | ✖                                                                        |

Related issues: Closes #711 

The port being set plays nicely even when using sqlite.
