### PR TITLE
Fix S2201: Replace .map() with for...of in player pause handling

### DIFF
--- a/docs/devguide/docs/assets/gallery/script.js
+++ b/docs/devguide/docs/assets/gallery/script.js
@@ -300,9 +300,13 @@
     });
 
     $window.on('hide.bs.modal', function(e) {
-        players.map(function(player, i) {
-            player.pauseVideo ? player.pauseVideo() : player.pause();
-        });
+        for (const player of players) {
+            if (player.pauseVideo) {
+                player.pauseVideo();
+            } else {
+                player.pause();
+            }
+        }
 
         flagShowLightBox = false;
     });


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                       |


Further  information:
### Overview
This PR fixes a SonarQube issue (javascript:S2201) where the return
value of `Array.prototype.map()` was ignored in the player pause logic.

### Changes
- Replaced `.map()` with a `for...of` loop for better readability.
- Ensured player pause functionality remains unchanged.
- Removed unnecessary return value creation to comply with Sonar rules.

### Why
- `.map()` is meant for transforming arrays, but the returned value was
  not being used.
- Using `for...of` clarifies the intention (iteration for side effects).
- Resolves Sonar warning `S2201: Return values should not be ignored`.

### Testing
- Verified that all players are paused correctly.
- No change in functionality, only code quality improvement.

